### PR TITLE
ROTN: Fix unit tests and gen errors

### DIFF
--- a/worlds/rotn/RiftCollections.py
+++ b/worlds/rotn/RiftCollections.py
@@ -215,7 +215,7 @@ class RotNCollections:
         for key, data in self.EXTRA_DATA.items():
             self.song_items[key] = SongData(data.code, key, data.DLC, 1, 0, 0, 0, data.DLC)
             self.song_items[key + " (Medium)"] = SongData(data.code + 1, key, data.DLC, 0, 1, 0, 0, data.DLC)
-            self.song_items[key + " (Hard)"] = SongData(data.code + 1, key, data.DLC, 0, 0, 1, 0, data.DLC)
+            self.song_items[key + " (Hard)"] = SongData(data.code + 2, key, data.DLC, 0, 0, 1, 0, data.DLC)
 
         self.item_names_to_id.update({name: data.code for name, data in self.song_items.items()})
 

--- a/worlds/rotn/RiftCollections.py
+++ b/worlds/rotn/RiftCollections.py
@@ -296,7 +296,7 @@ class RotNCollections:
             "Minigame": {name for name, data, in self.song_items.items() if data.type == "Minigame"},
             "Boss Battle": {name for name, data, in self.song_items.items() if data.type == "Boss"},
 
-            "Base Songs": {name for name, data, in self.song_items.items() if data.DLC == "base"},
+            "Base Songs": {name for name, data, in self.song_items.items() if data.DLC == "Base"},
             "Meat Boy": {name for name, data, in self.song_items.items() if data.DLC == "MeatBoy"},
             "Anniversary": {name for name, data, in self.song_items.items() if data.DLC == "Anniversary"},
             "Free Promo": {name for name, data, in self.song_items.items() if data.DLC == "Free Promo"},

--- a/worlds/rotn/__init__.py
+++ b/worlds/rotn/__init__.py
@@ -74,28 +74,28 @@ class RotNWorld(World):
             available_song_keys = self.rift_collection.getSongsWithSettings(self.options, min_diff, max_diff)
             available_song_keys = self.handle_plando(available_song_keys)
 
-            # Find the proposed goal songs and add them to a new list
-            victory_song_keys = []
-            for goal_song_canidate in goal_song_pool:
-                for index, available_song in enumerate(available_song_keys):
-                    if goal_song_canidate == available_song:
-                        # Include the canidates correlating index to the full list for later use
-                        victory_song_keys.append([index, available_song])
-
-            if victory_song_keys:
-                chosen_song_index = self.random.randrange(0, len(victory_song_keys))
-                self.victory_song_name = victory_song_keys[chosen_song_index][1]
-                self.victory_song_type = self.rift_collection.song_items[self.victory_song_name].type
-                # Replace the chosen goal song's index with the index from the full list we saved earlier.
-                chosen_song_index = victory_song_keys[chosen_song_index][0]
-            else:
-                chosen_song_index = self.random.randrange(0, len(available_song_keys))
-                self.victory_song_name = available_song_keys[chosen_song_index]
-                self.victory_song_type = self.rift_collection.song_items[self.victory_song_name].type
-            del available_song_keys[chosen_song_index]
-
             count_needed_for_start = max(0, starter_song_count - len(self.starting_songs))
             if len(available_song_keys) + len(self.included_songs) >= count_needed_for_start + 11:
+                # Find the proposed goal songs and add them to a new list
+                victory_song_keys = []
+                for goal_song_canidate in goal_song_pool:
+                    for index, available_song in enumerate(available_song_keys):
+                        if goal_song_canidate == available_song:
+                            # Include the canidates correlating index to the full list for later use
+                            victory_song_keys.append([index, available_song])
+
+                if victory_song_keys:
+                    chosen_song_index = self.random.randrange(0, len(victory_song_keys))
+                    self.victory_song_name = victory_song_keys[chosen_song_index][1]
+                    self.victory_song_type = self.rift_collection.song_items[self.victory_song_name].type
+                    # Replace the chosen goal song's index with the index from the full list we saved earlier.
+                    chosen_song_index = victory_song_keys[chosen_song_index][0]
+                else:
+                    chosen_song_index = self.random.randrange(0, len(available_song_keys))
+                    self.victory_song_name = available_song_keys[chosen_song_index]
+                    self.victory_song_type = self.rift_collection.song_items[self.victory_song_name].type
+                del available_song_keys[chosen_song_index]
+
                 final_song_list = available_song_keys
                 break
 


### PR DESCRIPTION
Fixed unit tests for the Base Songs group being empty and Medium and Hards from EXTRA_DATA having the same ID.

Goal song delayed until a viable pool is found, if ever. Only lightly tested with a specified goal song, all other testing against the apworld fuzzer to eliminate generation errors.

```YAML
# Before (1K)
Success: 813
Failures: 37
Timeouts: 0
Ignored: 150
```
```YAML
# After (10K)
Success: 8392
Failures: 0
Timeouts: 0
Ignored: 1608
```

---

Note that there is now an extremely rare off-by-one issue because the goal song is picked from the pool after the available song amount is checked:
```YAML
name: Player{number}
game: Rift of the Necrodancer
Rift of the Necrodancer:
  starting_song_count: 3
  additional_song_count: 15
  goal_song_pool: ["Cryp2que"]
  # Reduce the song pool to 14 songs
  exclude_songs: ['Disco Disaster', 'Elusional', 'Visualize Yourself', 'Spookhouse Pop', 'Om and On', 'Morning Dove', "Heph's Mess", 'Amalgamaniac', 'Hang Ten Heph', 'Count Funkula', 'Overthinker', 'Nocturning', 'Glass Cages (feat. Sarah Hubbard)', 'Hallow Queen', 'Progenitor', 'Matriarch', 'Under the Thunder', 'Eldritch House', 'RAVEVENGE (feat. Aram Zero)', 'Rift Within', "Suzu's Quest", 'Necropolis', 'Baboosh', 'Necro Sonatica', 'She Banned', "King's Ruse", "What's in the Box", 'Brave the Harvester', 'Final Fugue', 'Twombtorial', 'Portamello']
```
This YAML wants 18 songs with 36 locations, only 14/28 are available, and ultimately generates with 13/26.