### PR TITLE
Fix mutable class variables that were leaking state between worlds

### DIFF
--- a/worlds/rotn/__init__.py
+++ b/worlds/rotn/__init__.py
@@ -52,12 +52,15 @@ class RotNWorld(World):
     player_mod_remmap = {}
     victory_song_name: str = ""
     victory_song_type: int = 0
-    starting_songs: List[str] = []
-    included_songs: List[str] = []
-    final_song_ids: set[int] = set()
     location_count: int
 
     ut_can_gen_without_yaml = True
+
+    def __init__(self, multiworld, player):
+        super().__init__(multiworld, player)
+        self.starting_songs: List[str] = []
+        self.included_songs: List[str] = []
+        self.final_song_ids: set[int] = set()
 
     def generate_early(self):
         logger = logging.getLogger("RotN")


### PR DESCRIPTION
Initialize included_songs, starting_songs, and final_song_ids as instance variables in __init__ instead of class-level mutable defaults. The shared class-level lists/sets were mutated across multiple RotNWorld instances, causing state leaks in multiworlds with more than one ROTN.
